### PR TITLE
Make app config minification-safe

### DIFF
--- a/src/angularJS/routes.js
+++ b/src/angularJS/routes.js
@@ -6,7 +6,7 @@ import './expanded.component.js';
 
 angular
     .module('angularJS-app')
-    .config(($stateProvider, $locationProvider) => {
+    .config(["$stateProvider", "$locationProvider", ($stateProvider, $locationProvider) => {
         $locationProvider.html5Mode({
             enabled: true,
             requireBase: false,
@@ -20,4 +20,4 @@ angular
                 url: '/expanded',
                 template: '<expanded />',
             })
-    });
+    }]);


### PR DESCRIPTION
Hey Alex! I dug into the issue you reported to me on Slack and found a solution. It turns out that the problem isn't in single-spa but rather in the way AngularJS configs need to be written in order to make them minification-safe, which I found out from this [SO question regarding the same `Error: [$injector:unpr] Unknown provider: n`](https://stackoverflow.com/questions/33011500/minification-issue-on-route-config-angular-js-typescript-min-safe). I haven't written AngularJS code in a long time so I only distantly recall why this is necessary. With this, the app loads fine in dev mode as well as in prod builds. 

I tested this by running `yarn build` and then `npx serve -s` to serve the local build assets. It would be great to update our documentation so that others don't face this issue, would you mind sending us a PR for that? 

Also, by way of information, we are moving away from this setup and are settling on a [recommended setup](https://single-spa.js.org/docs/faq/#is-there-a-recommended-setup) that uses import-maps and SystemJS to load modules in the browser. This does get tricky with older code that was written before modules became part of the standard and so it may not work for all cases. Just something for you to consider. Hope this helps! 